### PR TITLE
Add labels to MOCs

### DIFF
--- a/templates/tom_targets/partials/aladin_skymap.html
+++ b/templates/tom_targets/partials/aladin_skymap.html
@@ -125,6 +125,7 @@
         var mocFileUrl = "{% static 'tom_common/moc/base51_for_OPM_600visits.fits' %}";
             var moc_base51_600visits = A.MOCFromURL(mocFileUrl, {
                 color: '#ffa040',
+                name: 'Rubin',
                 lineWidth: 2,
                 opacity: 0.4
             });
@@ -135,6 +136,7 @@
             var moc_nolodust = A.MOCFromURL(mocFileUrl, {
                 color: '#ff0000',
                 lineWidth: 2,
+                name: 'Galactic Plane Survey',
                 opacity: 0.3
             });
 
@@ -143,6 +145,7 @@
         var mocFileUrl = "{% static 'tom_common/moc/gaia_nsquare_for_OPM_moc_nes.fits' %}";
             var moc_nes = A.MOCFromURL(mocFileUrl, {
                 color: '#6666ff',
+                name: 'North Ecliptic Spur',
                 lineWidth: 2,
                 opacity: 0.3
             });


### PR DESCRIPTION
Currently, most of the overlays say "MOC". 
<img width="946" height="568" alt="image" src="https://github.com/user-attachments/assets/5c2f0d8a-1e82-40b5-8777-19895cba39b6" />

This PR gives them more meaningful labels.
<img width="982" height="632" alt="image" src="https://github.com/user-attachments/assets/48c9a865-4cca-4245-918e-7daec4fb67ae" />


Fixes #99 