### PR TITLE
rm spurious target save

### DIFF
--- a/custom_code/brokers/alerce_lsst.py
+++ b/custom_code/brokers/alerce_lsst.py
@@ -179,8 +179,6 @@ class ALERCEBroker(GenericBroker):
                 print('ALERCE HARVESTER: Found duplicated data for event '+target.name)
 
 
-        target.save()
-
         return 'OK'
 
 

--- a/custom_code/brokers/alerce_ztf.py
+++ b/custom_code/brokers/alerce_ztf.py
@@ -213,7 +213,6 @@ class ALERCEBroker(GenericBroker):
                     print('ALERCE HARVESTER: Found duplicated data for event '+target.name)
                 
 
-        target.save()
         return 'OK'
 
 

--- a/custom_code/brokers/ogle.py
+++ b/custom_code/brokers/ogle.py
@@ -195,8 +195,6 @@ class OGLEBroker(GenericBroker):
             except MultipleObjectsReturned:
                 print('OGLE HARVESTER: Found duplicated data for event '+target.name)
 
-        target.save()
-
         return 'OK'
 
     def sort_target_list(self, list_of_targets):


### PR DESCRIPTION
target.save() called on former instance, loosing updates. Fix tested locally.