### PR TITLE
revise psip trained with sigma 0

### DIFF
--- a/custom_code/management/commands/run_probability_rescaling.py
+++ b/custom_code/management/commands/run_probability_rescaling.py
@@ -43,7 +43,7 @@ class Command(BaseCommand):
             if target_classification.exists():
                 time_now = Time(datetime.datetime.now()).jd
                 try:
-                    psip = psi_planet_priority_peak(microlensing_model.u0, microlensing_model.err_u0)
+                    psip = psi_planet_priority_peak(microlensing_model.u0, microlensing_model.err_u0, sigma_threshold = 0)
                     reshaped_value = np.array([[psip]])
                     transformed_prob_planet = model_qt_psi.transform(reshaped_value)
                 except:

--- a/custom_code/management/commands/run_rtmodel_fits.py
+++ b/custom_code/management/commands/run_rtmodel_fits.py
@@ -21,11 +21,10 @@ from django.db import connection, transaction
 from ._RTModel_results_cls import EventResults, ModelResults
 
 def run_fit(target):
-    if "ZTF26" in target.name or "LSST" in target.name or "OGLE" in target.name:
+    if "ZTF2" in target.name or "LSST" in target.name or "OGLE" in target.name:
         target_id = target.id 
         tempdirname = 'event001'
-        print(target.name)
-
+        print(f"Prepare RTModel fit for {target.name}")
         with tempfile.TemporaryDirectory() as tempdirname:      
             data_dir = path.join(tempdirname,'Data')
             makedirs(data_dir)


### PR DESCRIPTION
re-scaling for psi was carried out for nominal, best fit parameters. The conservative correction by some uncertainty is inconsistent and due to large uncertainties also wrong as error propagation. A minor fix for hard-coded ZTF year is included. 