### PR TITLE
Add git commit hash to footer and endpoint version/

### DIFF
--- a/compose.base.yaml
+++ b/compose.base.yaml
@@ -20,6 +20,7 @@ services:
       DJANGO_CSRF_TRUSTED_ORIGIN: ${DJANGO_CSRF_TRUSTED_ORIGIN}
       E2E: 0
       LOCAL: 0
+      GIT_COMMIT: ${GIT_COMMIT:-n.a.}
     command: /galactic_science_opm/entrypoint.sh
     stop_grace_period: 1s
 

--- a/compose.e2e.yaml
+++ b/compose.e2e.yaml
@@ -31,3 +31,4 @@ services:
       - galactic-science-opm-db-test
     environment:
       BASE_URL: ${BASE_URL:-http://frontend-proxy:80}
+      GIT_COMMIT: ${GIT_COMMIT:-n.a.}

--- a/custom_code/context_processors.py
+++ b/custom_code/context_processors.py
@@ -1,0 +1,9 @@
+from django.conf import settings
+
+def version_info(_request):
+    """
+    Provides the git commit hash (if provided via env) to use in a template.
+    """
+    return {
+        "git_commit": settings.GIT_COMMIT,
+    }

--- a/custom_code/tests/e2e/pages/home_page.py
+++ b/custom_code/tests/e2e/pages/home_page.py
@@ -22,4 +22,7 @@ class HomePage:
     def register(self, username, first_name, last_name, email, password, password_confirm, affiliation):
         user_page = UsersPage(self.page, self.base_url)
         user_page.register(username, first_name, last_name, email, password, password_confirm, affiliation)
+
+    def get_commit_hash_container(self):
+        return self.page.get_by_test_id("commit-hash-container")
         

--- a/custom_code/tests/e2e/test_home_page.py
+++ b/custom_code/tests/e2e/test_home_page.py
@@ -124,5 +124,4 @@ def test_git_hash_is_visible(page: Page):
     home_page = HomePage(page, BASE_URL)
     home_page.open_it()
     commit_hash_container = home_page.get_commit_hash_container()
-    # must be set somewhere
     expect(commit_hash_container).to_contain_text(re.compile(f"{os.environ.get('GIT_COMMIT')}"))

--- a/custom_code/tests/e2e/test_home_page.py
+++ b/custom_code/tests/e2e/test_home_page.py
@@ -1,3 +1,4 @@
+import os
 import re
 from playwright.sync_api import Page, expect
 from custom_code.tests.e2e.data.test_data import BASE_URL, BROKER_LINKS, REGISTERABLE_USER, TOP_TARGETS, VALID_USER_CREDENTIALS
@@ -119,3 +120,9 @@ def test_shows_top_targets_in_descending_order(page: Page):
         expect(footer_privacy).to_be_visible()
         expect(footer_privacy).to_have_attribute("href", "https://www.uni-heidelberg.de/en/privacy-statement")
 
+def test_git_hash_is_visible(page: Page):
+    home_page = HomePage(page, BASE_URL)
+    home_page.open_it()
+    commit_hash_container = home_page.get_commit_hash_container()
+    # must be set somewhere
+    expect(commit_hash_container).to_contain_text(re.compile(f"{os.environ.get('GIT_COMMIT')}"))

--- a/custom_code/tests/e2e/test_ranking_page.py
+++ b/custom_code/tests/e2e/test_ranking_page.py
@@ -1,4 +1,5 @@
 import re
+from datetime import datetime, date
 from playwright.sync_api import Page, expect
 from custom_code.tests.e2e.data.test_data import BASE_URL, BROKER_LINKS
 from custom_code.tests.e2e.pages.ranking_page import RankingPage
@@ -7,11 +8,18 @@ NUMBER_OF_ELEMENTS_WITH_CORRECT_PROBABILITY = 11
 
 def test_all_targets_are_displayed(page: Page):
     pks_per_row = (3,4,6)
+    creation_date = "2026-04-30"
+    as_date = datetime.strptime(creation_date, "%Y-%m-%d").date()
+    def days_ago(d):
+        return (date.today() - d).days
+
+    created_ago = days_ago(as_date)
     expected_rows = (
         (
             r"ZTF26aarbgfh\s+ALeRCE\s+fink\s+ANTARES",
             0.4639,
-            "None",
+            "None, queried",
+            created_ago,
             0.923,
             0.932,
             0.000,
@@ -23,7 +31,8 @@ def test_all_targets_are_displayed(page: Page):
         (
             r"ZTF26aaivmks\s+ALeRCE\s+fink\s+ANTARES",
             0.4616,
-            "None",
+            "None, queried",
+            created_ago,
             0.920,
             0.926,
             0.000,
@@ -35,7 +44,8 @@ def test_all_targets_are_displayed(page: Page):
         (
             r"ZTF26aajaofr\s+ALeRCE\s+fink\s+ANTARES",
             0.4580,
-            "None",
+            "None, queried",
+            created_ago,
             0.925,
             0.907,
             0.000,

--- a/custom_code/views.py
+++ b/custom_code/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.core import management
 from django.db import OperationalError, connections
 from django.http import JsonResponse
@@ -7,15 +8,8 @@ from custom_code.target_models import GalacticTarget
 from custom_code.target_models import MicrolensingModel
 from custom_code.target_models import Classification
 from custom_code.target_models import MicrolensingRadarData
-from django.db.models import OuterRef, Subquery
 from django.views.generic import TemplateView
-from django.shortcuts import render, get_object_or_404
-import plotly.graph_objects as go
 from django.utils import timezone
-from datetime import datetime
-from plotly.offline import plot
-from os import path
-from itertools import chain
 
 def microlensing_model_view(request):
     microlensing_models = MicrolensingModel.objects.all()[:30]  # Get 30 MicrolensingModels
@@ -130,5 +124,10 @@ def flush_and_seed(_request):
         "seed_e2e_data"
     )
     return JsonResponse({"status": "seeding_done"}, status=201)
+
+def version(_request):
+    return JsonResponse({
+        "commit": settings.GIT_COMMIT,
+    })
 
 

--- a/galactic_science_opm/settings.py
+++ b/galactic_science_opm/settings.py
@@ -104,6 +104,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'custom_code.context_processors.version_info',
             ],
         },
     },
@@ -441,6 +442,8 @@ BOOTSTRAP4 = {
     "javascript_url": os.path.join(STATIC_URL, "bootstrap.bundle.min.js"),
     "jquery_url": os.path.join(STATIC_URL, "jquery-3.5.1.min.js")
 }
+
+GIT_COMMIT = os.environ.get("GIT_COMMIT", "n.a.")
 
 try:
     from local_settings import * # noqa

--- a/galactic_science_opm/urls.py
+++ b/galactic_science_opm/urls.py
@@ -24,7 +24,8 @@ urlpatterns = [
     path('', include('tom_common.urls')),
     path('custom_code/model_list.html', views.microlensing_model_view, name='microlensing_model_view'),
     path('custom_code/prob_list.html', views.microlensing_rescaled_prob_view, name='microlensing_rescaled_prob_view'),
-    path('health/', views.health, name="health")
+    path('health/', views.health, name="health"),
+    path('version/', views.version, name="version"),
 ]
 
 if settings.DEBUG:

--- a/static/tom_common/css/custom.css
+++ b/static/tom_common/css/custom.css
@@ -47,6 +47,7 @@
   --color-highlight-primary: #c50d29;
   --color-link: #709bc9;
   --color-link--hover: #36a9ff;
+  --color-footer--tertiary: #aaaaaa;
 
 }
 
@@ -227,4 +228,15 @@ td, th {
   background: var(--color-highlight-primary);
   display: inline-block;
   margin: 0 var(--spacing-025) 0 0;
+}
+
+.deployed-commit-hash {
+  color: var(--color-footer--tertiary);
+  font-family: var(--font-family-monospace);
+  font-size: var(--font-size-100);
+}
+
+.deployed-commit-hash code {
+  color: inherit;
+  font-size: inherit;
 }

--- a/templates/tom_common/base.html
+++ b/templates/tom_common/base.html
@@ -69,17 +69,24 @@
   {% block extra_javascript %}
   {% endblock %}
   <footer class="bg-dark text-center py-3 mt-auto">
-  <div class="container">
-    <div class="row">
-       <div class="col-md-8">
-          <a href="https://www.uni-heidelberg.de/de/impressum">Impressum</a> / <a href="https://www.uni-heidelberg.de/en/imprint">Imprint </a> 
-          <span class="text-light"> &mdash; </span> 
-          <a href="https://www.uni-heidelberg.de/de/datenschutzerklaerung">Datenschutzerklärung</a> / <a href="https://www.uni-heidelberg.de/en/privacy-statement">Privacy Statement</a>
-
+    <div class="container">
+      <div class="row">
+        <div class="col">
+          <a href="https://www.uni-heidelberg.de/de/impressum">Impressum</a> / <a
+            href="https://www.uni-heidelberg.de/en/imprint">Imprint </a>
+          <span class="text-light"> &mdash; </span>
+          <a
+            href="https://www.uni-heidelberg.de/de/datenschutzerklaerung">Datenschutzerklärung</a>
+          / <a href="https://www.uni-heidelberg.de/en/privacy-statement">Privacy
+            Statement
+          </a>
+        </div>
+      </div>
+      <div class="row">
+        <div class="deployed-commit-hash col">Version: <code>{{ git_commit }}</code></div>
       </div>
     </div>
-  </div>
-</footer>
+  </footer>
 
   </body>
 </html>

--- a/templates/tom_common/base.html
+++ b/templates/tom_common/base.html
@@ -83,7 +83,7 @@
         </div>
       </div>
       <div class="row">
-        <div class="deployed-commit-hash col">Version: <code>{{ git_commit }}</code></div>
+        <div class="deployed-commit-hash col" data-testid="commit-hash-container">Version: <code>{{ git_commit }}</code></div>
       </div>
     </div>
   </footer>


### PR DESCRIPTION
This commit adds a way to add a git commit to the footer and also allows getting it via the endpoint `version/`.

The commit hash is passed in via an env variable called `GIT_COMMIT`. This needs to be set when running docker compose up. Like this, e.g.:

```sh
export GIT_COMMIT=$(git rev-parse --short HEAD)
docker compose up -d
```

If no value is provided, it will show "n.a.".

<img width="758" height="117" alt="image" src="https://github.com/user-attachments/assets/53b30d22-0512-41df-b44d-f43bf3a11649" />

Fixes #133 