### PR TITLE
Feature/78 share data to mop

### DIFF
--- a/custom_code/templates/custom_code/tabs/observe.html
+++ b/custom_code/templates/custom_code/tabs/observe.html
@@ -4,6 +4,7 @@
         
         <div>
           <a class="btn btn-outline-secondary" href="/download-data/lightcurves/{{target.id}}">Download lightcurve data for target</a>
+          {% target_buttons target %}
         </div>
       
 </div>

--- a/galactic_science_opm/settings.py
+++ b/galactic_science_opm/settings.py
@@ -456,6 +456,15 @@ BOOTSTRAP4 = {
 
 GIT_COMMIT = os.environ.get("GIT_COMMIT", "n.a.")
 
+DATA_SHARING = {
+    'mop-tom': {
+        'DISPLAY_NAME': os.getenv('MOP_TOM_DISPLAY_NAME', 'MOP'),
+        'BASE_URL': os.getenv('MOP_TOM_BASE_URL'),
+        'USERNAME': os.getenv('MOP_TOM_USERNAME'),
+        'PASSWORD': os.getenv('MOP_TOM_PASSWORD'),
+    }
+}
+
 try:
     from local_settings import * # noqa
 except ImportError:

--- a/templates/tom_targets/partials/create_persistent_share.html
+++ b/templates/tom_targets/partials/create_persistent_share.html
@@ -16,9 +16,9 @@
       </div>
       <div class="col-sm-1">
         {% if target %}
-        <input type="button" class="btn btn-primary" value="Create" onclick="createPersistentShare('{% url 'targets:persistent-share' %}', '{% url 'targets:target-persistent-share-manage-table' target.pk %}')" style="position:absolute; bottom:1rem"/>
+        <input type="button" class="btn btn-primary" value="Create" onclick="createPersistentShare('{% url 'targets:persistent-share' %}', '{% url 'targets:target-persistent-share-manage-table' target.pk %}')" />
         {% else %}
-        <input type="button" class="btn btn-primary" value="Create" onclick="createPersistentShare('{% url 'targets:persistent-share' %}', '{% url 'targets:persistent-share-manage-table' %}')" style="position:absolute; bottom:1rem"/>
+        <input type="button" class="btn btn-primary" value="Create" onclick="createPersistentShare('{% url 'targets:persistent-share' %}', '{% url 'targets:persistent-share-manage-table' %}')" />
         {% endif %}
       </div>
   </div>

--- a/templates/tom_targets/partials/target_buttons.html
+++ b/templates/tom_targets/partials/target_buttons.html
@@ -1,6 +1,6 @@
 {% load targets_extras %}
 <div class="btn-group" role="group" aria-label="Target detail buttons">
     {% if sharing %}
-      <a href="{% url 'tom_targets:share' pk=target.id %}" title="Share target" class="btn btn-info">Share</a>
+      <a href="{% url 'targets:share' pk=target.id %}" title="Share target" class="btn btn-info">Share</a>
     {% endif %}
 </div>

--- a/templates/tom_targets/partials/target_buttons.html
+++ b/templates/tom_targets/partials/target_buttons.html
@@ -1,9 +1,6 @@
 {% load targets_extras %}
 <div class="btn-group" role="group" aria-label="Target detail buttons">
-    <a href="{% url 'tom_targets:update' pk=target.id %}" title="Update target" class="btn btn-primary">Update</a>
     {% if sharing %}
-    <a href="{% url 'tom_targets:share' pk=target.id %}" title="Share target" class="btn btn-info">Share</a>
+      <a href="{% url 'tom_targets:share' pk=target.id %}" title="Share target" class="btn btn-info">Share</a>
     {% endif %}
-    <a href="{% url 'tom_targets:delete' pk=target.id %}" title="Delete target" class="btn btn-warning">Delete</a>
-    {% get_buttons target %}
 </div>

--- a/templates/tom_targets/target_share.html
+++ b/templates/tom_targets/target_share.html
@@ -11,10 +11,10 @@
 <div class="col-md-8">
   <ul class="nav nav-tabs" role="tablist" id="share-tabs">
     <li class="nav-item">
-      <a class="nav-link active" id="share-tab" href="#share" role="tab" data-toggle="tab">Share {{ target.name }}</a>
+      <a class="nav-link active" id="share-tab" href="#share" role="tab" data-bs-toggle="tab">Share {{ target.name }}</a>
     </li>
     <li class="nav-item">
-      <a class="nav-link" id="persistentshare-tab" href="#persistentshare" role="tab" data-toggle="tab">Persistent
+      <a class="nav-link" id="persistentshare-tab" href="#persistentshare" role="tab" data-bs-toggle="tab">Persistent
         Sharing</a>
     </li>
   </ul>
@@ -32,7 +32,7 @@
           </div>
           <div class="col-sm-1">
             <input type="submit" class="btn btn-primary" formaction="{% url 'targets:share' pk=target.id %}"
-              id="submit_target" value="Submit" name="share_target_form" style=""
+              id="submit_selected_phot" value="Submit" name="share_target_form" style=""
               onclick="setTarget('')">
           </div>
           {% if hermes_sharing %}

--- a/templates/tom_targets/target_share.html
+++ b/templates/tom_targets/target_share.html
@@ -1,9 +1,9 @@
 {% extends 'tom_common/base.html' %}
 {% load django_bootstrap5 targets_extras dataproduct_extras static %}
 {% block title %}Share Target {{ target.name }}{% endblock %}
-{% block additional_css %}
 <link rel="stylesheet" href="{% static 'tom_common/css/main.css' %}">
 <link rel="stylesheet" href="{% static 'tom_targets/css/main.css' %}">
+{% block additional_css %}
 <script src="https://cdn.jsdelivr.net/npm/js-base64@3.7.5/base64.min.js"></script>
 {% endblock %}
 {% block content %}
@@ -32,7 +32,7 @@
           </div>
           <div class="col-sm-1">
             <input type="submit" class="btn btn-primary" formaction="{% url 'targets:share' pk=target.id %}"
-              id="submit_target" value="Submit" name="share_target_form" style="position:absolute; bottom:1rem"
+              id="submit_target" value="Submit" name="share_target_form" style=""
               onclick="setTarget('')">
           </div>
           {% if hermes_sharing %}
@@ -67,7 +67,6 @@
       <h3>Manage Continuous Sharing for Target <a href="{% url 'targets:detail' pk=target.id %}"
           title="Back">{{ target.name }}</a></h3>
       <div id='target-persistent-share-table'>
-        {% persistent_share_table target %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
**THIS DOES NOT WORK FULLY, YET.**
Regular sharing seems to work, but persistent sharing does not. There might be a bug in tomtoolkit but it might be something on our side as well.

-------------

The main purpose of this PR is to share data between our TOM and MOP. 
To try this out with another (maybe locally running) TOM, the following variables have to be set in your `.env`:
``` sh
MOP_TOM_DISPLAY_NAME
MOP_TOM_BASE_URL
MOP_TOM_USERNAME
MOP_TOM_PASSWORD
```

This will add a "Share" button in the "Exchange" tab on a target page and the TOM that was configured via your `.env` will appear as a potential sharing destination:
<img width="1384" height="642" alt="image" src="https://github.com/user-attachments/assets/dfbacf22-5439-4f4a-a787-627fc4ae0f6b" />


