### PR TITLE
Add minimal metrics endpoint

### DIFF
--- a/custom_code/views.py
+++ b/custom_code/views.py
@@ -1,12 +1,14 @@
-import io
+from datetime import timedelta
 import os
 import tempfile
 import zipfile
 from astropy.time import Time
+from django.contrib.auth.models import User
 import numpy as np
-from tom_dataproducts.models import PhotometryReducedDatum, ReducedDatum
+from tom_dataproducts.models import PhotometryReducedDatum
 from django.conf import settings
 from django.core import management
+from django.views.decorators.cache import cache_page
 from django.db import OperationalError, connections
 from django.http import FileResponse, JsonResponse
 from django.shortcuts import render
@@ -308,3 +310,25 @@ def version(_request):
     return JsonResponse({
         "commit": settings.GIT_COMMIT,
     })
+
+@cache_page(60)
+def metrics(_request):
+
+    now = timezone.now()
+    metrics = {
+        "commit": settings.GIT_COMMIT,
+        "new_users_last_24h": User.objects.filter(
+                date_joined__gte=now - timedelta(hours=24)
+            ).count(),
+        "pending_users": User.objects.filter(is_active=False).count(),
+        "new_targets_last_24h": GalacticTarget.objects.filter(
+                created__gte=now - timedelta(hours=24)
+            ).count(),
+        "new_targets_last_48h": GalacticTarget.objects.filter(
+                created__gte=now - timedelta(hours=48)
+            ).count(),
+        "new_targets_last_72h": GalacticTarget.objects.filter(
+                created__gte=now - timedelta(hours=72)
+            ).count(),
+    }
+    return JsonResponse(metrics)

--- a/galactic_science_opm/urls.py
+++ b/galactic_science_opm/urls.py
@@ -32,6 +32,7 @@ urlpatterns = [
     path('custom_code/prob_list.html', views.microlensing_rescaled_prob_view, name='microlensing_rescaled_prob_view'),
     path('health/', views.health, name="health"),
     path('version/', views.version, name="version"),
+    path('metrics/', views.metrics, name="metrics"),
     path('download-data/lightcurves/<int:pk>/', views.download_lightcurve_data_for_target, name='download_lightcurve_data_for_target'),
 ]
 


### PR DESCRIPTION
Currently this has no required auth. But it would probably be good to only allow internal access. Maybe in nginx or some other place you have control over, @astroadmin?
