### PR TITLE
Remove download from select destination and fix bug when deselecting photmetry

### DIFF
--- a/custom_code/views.py
+++ b/custom_code/views.py
@@ -13,6 +13,8 @@ from django.db import OperationalError, connections
 from django.http import FileResponse, JsonResponse
 from django.shortcuts import render
 from django.core.exceptions import ObjectDoesNotExist
+from tom_dataproducts.sharing import get_sharing_destination_options
+from tom_targets.forms import TargetShareForm
 from custom_code.target_models import GalacticTarget, MicrolensingParameterModel
 from custom_code.target_models import Classification
 from custom_code.target_models import MicrolensingRadarData
@@ -21,7 +23,7 @@ from django.views.generic import TemplateView
 from django.utils import timezone
 
 from custom_code.utils.catalog_requests import NOT_IN_ANY_CATALOG
-from tom_targets.views import TargetDetailView
+from tom_targets.views import TargetDetailView, TargetShareView
 def microlensing_model_view(request):
     microlensing_models = MicrolensingParameterModel.objects.all()[
         :30
@@ -209,6 +211,27 @@ class GsoOpmTargetDetailView(TargetDetailView):
         target = self.object
         context["latest_parameter_models"] = target.latest_parameter_models()
         return context
+
+class GsoOpmTargetShareForm(TargetShareForm):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['share_destination'].choices = get_sharing_destination_options(include_download = False)
+
+class GsoOpmTargetShareView(TargetShareView):
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        target = context['target']
+        initial = {
+            'submitter': self.request.user,
+            'share_title': f'Updated data for {target.name}'
+        }
+
+        form = GsoOpmTargetShareForm(initial=initial)
+        context['form'] = form
+
+        return context
+
 
 # mkistner: This was taken from here: 
 # https://github.com/LCOGT/mop/blob/600eed8c6d420c709a13bb2310e6310e9248a2b7/mop/toolbox/fittools.py

--- a/galactic_science_opm/urls.py
+++ b/galactic_science_opm/urls.py
@@ -16,7 +16,7 @@ Including another URLconf
 from django.urls import path, include
 from django.conf import settings
 from django.conf.urls.static import static
-from custom_code.views import GsoOpmTargetDetailView, HomeView
+from custom_code.views import GsoOpmTargetDetailView,GsoOpmTargetShareView, HomeView
 from custom_code import views
 
 urlpatterns = [
@@ -26,6 +26,7 @@ urlpatterns = [
         GsoOpmTargetDetailView.as_view(),
         name="target-detail",
     ),
+    path('targets/<int:pk>/share/', GsoOpmTargetShareView.as_view(), name='share'),
     path('', include('tom_common.urls')),
     path('custom_code/model_list.html', views.microlensing_model_view, name='microlensing_model_view'),
     path('custom_code/prob_list_lsst.html', views.microlensing_rescaled_prob_view_lsst, name='microlensing_rescaled_prob_view_lsst'),

--- a/templates/tom_dataproducts/partials/photometry_datalist_for_target.html
+++ b/templates/tom_dataproducts/partials/photometry_datalist_for_target.html
@@ -1,0 +1,109 @@
+
+{% load django_bootstrap5 %}
+{% load tom_common_extras %}
+
+<form method="POST" action="{% url 'tom_dataproducts:share_all' tg_pk=target.id %}" enctype="multipart/form-data" id="photometry-data-share-form">
+    {% csrf_token %}
+      {% for hidden in target_data_share_form.hidden_fields %}
+        {{ hidden }}
+      {% endfor %}
+    <div class="card">
+        <div class="card-header">
+          Photometry Data
+        </div>
+        <table id="photData" class="table table-striped table-hover table-sm" cellspacing="0" width="100%">
+            <thead>
+                <tr><th><div class="form-check">
+                    <input type="checkbox" class="form-check-input" id="share-all-phot" onclick="select_all_phot()" value=""/>
+                    <label class="form-check-label" for="share-all-phot">Share</label>
+                    </div></th>
+                    <th>Timestamp</th>
+                    <th>Telescope</th>
+                    <th>Filter</th>
+                    <th>Magnitude</th>
+                    <th>Error</th>
+                    <th>Source</th>
+                </tr>
+            </thead>
+            <tbody>
+            {% for datum in data %}
+            <tr>
+                <td><input type="checkbox" class="phot-row" id="phot-row-{{ datum.id }}" name="share-box" value="{{ datum.id }}" onchange="check_selected_phot()"></td>
+                <td>{{ datum.timestamp }}</td>
+                <td>{{ datum.telescope }}</td>
+                <td>{{ datum.filter }}</td>
+                <td>
+                    <!-- prepend greater-than sign if this is a magnitude limit -->
+                    {% if datum.limit %}>{% endif %}
+                    {{ datum.magnitude|truncate_value_for_display }}
+                </td>
+                {% if datum.error %}
+                    <td>{{ datum.error|truncate_value_for_display:5 }}</td>
+                {% else %}
+                    <td>{{ datum.magnitude_error|floatformat:4 }}</td>
+                {% endif %}
+                <td>{{ datum.source }}</td>
+            </tr>
+            {% empty %}
+            <tr>
+                <td colspan="2">No Photometry Data.</td>
+            </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+        {% if not target_share %}
+            <div class="card">
+                <div class="card-header">
+                    Share Selected Data
+                </div>
+                {% if sharing_destinations %}
+                    <div class="row" style="padding-inline:1rem">
+                        <div class="col-sm-12">
+                            {% bootstrap_field target_data_share_form.share_title %}
+                        </div>
+                    </div>
+                    <div class="row" style="padding-inline:1rem">
+                        <div class="col-sm-12">
+                            {% bootstrap_field target_data_share_form.share_message %}
+                        </div>
+                    </div>
+                    <div class="row" style="padding-inline:1rem">
+                        <div class="col-sm-4">
+                            {% bootstrap_field target_data_share_form.share_destination %}
+                        </div>
+                        <div class="col-sm-2 offset-sm-1">
+                            <input type="submit" class="btn btn-primary" id="submit_selected_phot" value="Submit" name="share_targetdata_form" style="position:absolute; bottom:1rem" disabled onclick="setTargetOnPhotometryForm('')">
+                        </div>
+                    </div>
+                {% else %}
+                    <em style="padding-inline:1rem">Not Configured. See
+                        <a href="https://tom-toolkit.readthedocs.io/en/stable/managing_data/tom_direct_sharing.html"
+                           target="_blank">Documentation</a>.</em>
+                {% endif %}
+            </div>
+        {% endif %}
+    </div>
+</form>
+<script>
+  const photometryShareForm = document.getElementById('photometry-data-share-form');
+  function setTargetOnPhotometryForm(val) {
+      if (val && val != '') {
+        photometryShareForm.setAttribute('target', val);
+      }
+      else{
+        photometryShareForm.removeAttribute('target');
+      }
+      return true;
+  }
+  function select_all_phot()  {
+    const share_all = document.getElementById("share-all-phot");
+       const shareRows = document.querySelectorAll('input[name="share-box"].phot-row');
+       shareRows.forEach((row) => {
+          row.checked = share_all.checked;
+       });
+       check_selected_phot()
+    }
+  function check_selected_phot()  {
+    // not needed
+  }
+</script>


### PR DESCRIPTION
Removed the standard download destination (does not work at the moment).

When deselecting all photometry, the submit button was disabled. Since it is valid to share a target without photometry, the code that disabled the submit button was removed.
--> had to copy templates/tom_dataproducts/partials/photometry_datalist_for_target.html for this change. 