### PR TITLE
Feature/208 loading indicator plotly aladin

### DIFF
--- a/frontend/src/components/aladin-lite-element/AladinLiteElement.ts
+++ b/frontend/src/components/aladin-lite-element/AladinLiteElement.ts
@@ -1,5 +1,7 @@
 import { html, css, LitElement, type PropertyValues } from "lit";
 import { property } from "lit/decorators.js";
+import type { LoadingIndicatorElement } from "../loading-indicator-element/LoadingIndicatorElement";
+import "../loading-indicator-element/loading-indicator-element"
 
 // The AladinLite API does not provide a way to draw arbitrary text at an arbitrary location in an overlay layer.
 // This implements the methods necessary to do so when provided as an input to layer.add(). This approach was
@@ -272,6 +274,11 @@ export class AladinLiteElement extends LitElement {
 
   onReady() {
     this.annotateChart(this.ra, this.dec);
+
+    const loadingIndicator = this.shadowRoot?.querySelector<LoadingIndicatorElement>("loading-indicator-element")
+    if (!loadingIndicator) return;
+    loadingIndicator.hide();
+
   }
 
   getScaleBarFromForm() {
@@ -472,6 +479,7 @@ export class AladinLiteElement extends LitElement {
 
   render() {
     return html`
+      <loading-indicator-element></loading-indicator-element>
       <slot></slot>
       <div id="chart-form-div">
         <div id="chart-form" class="inline-flex gap-s align-fe p-b-s">

--- a/frontend/src/components/loading-indicator-element/LoadingIndicatorElement.ts
+++ b/frontend/src/components/loading-indicator-element/LoadingIndicatorElement.ts
@@ -1,0 +1,71 @@
+import { html, css, LitElement, type PropertyValues } from "lit";
+import { property } from "lit/decorators.js";
+
+export class LoadingIndicatorElement extends LitElement {
+  @property({ type: Object })
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+    .loader {
+      --color-1: #fff;
+      --color-2: #ff3d00;
+      --size: 1px;
+
+      width: calc(48 * var(--size));
+      height: calc(48 * var(--size));
+      border: calc(5 * var(--size)) solid var(--color-1);
+      border-bottom-color: var(--color-2);
+      border-radius: 50%;
+      display: inline-block;
+      box-sizing: border-box;
+      animation: rotation 1s linear infinite;
+    }
+
+    @keyframes rotation {
+      0% {
+        transform: rotate(0deg);
+      }
+      100% {
+        transform: rotate(360deg);
+      }
+    }
+
+    .hidden {
+      display: none;
+    }
+
+  `;
+
+  constructor() {
+    super();
+  }
+
+  connectedCallback(): void {
+    super.connectedCallback();
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+  }
+
+  hide() {
+    const el = this.shadowRoot?.querySelector("#loading-indicator")
+    if (!el) return;
+    el.classList.add("hidden")
+  }
+
+  show() {
+    const el = this.shadowRoot?.querySelector("#loading-indicator")
+    if (!el) return;
+    el.classList.remove("hidden")
+  }
+
+  render() {
+    return html`
+      <span id="loading-indicator" class="loader"></span>
+    `;
+  }
+}
+

--- a/frontend/src/components/loading-indicator-element/LoadingIndicatorElement.ts
+++ b/frontend/src/components/loading-indicator-element/LoadingIndicatorElement.ts
@@ -1,4 +1,4 @@
-import { html, css, LitElement, type PropertyValues } from "lit";
+import { html, css, LitElement } from "lit";
 import { property } from "lit/decorators.js";
 
 export class LoadingIndicatorElement extends LitElement {

--- a/frontend/src/components/loading-indicator-element/loading-indicator-element.ts
+++ b/frontend/src/components/loading-indicator-element/loading-indicator-element.ts
@@ -1,0 +1,3 @@
+import { LoadingIndicatorElement } from "./LoadingIndicatorElement";
+
+customElements.define("loading-indicator-element", LoadingIndicatorElement)

--- a/frontend/src/components/plotly-chart-element/PlotlyChartElement.ts
+++ b/frontend/src/components/plotly-chart-element/PlotlyChartElement.ts
@@ -1,6 +1,9 @@
 import { html, css, LitElement, type PropertyValues } from "lit";
 import { property } from "lit/decorators.js";
 
+import "../loading-indicator-element/loading-indicator-element"
+import type { LoadingIndicatorElement } from "../loading-indicator-element/LoadingIndicatorElement";
+
 export class PlotlyChartElement extends LitElement {
   @property({ type: Object })
   config: Record<string, any> | undefined = undefined;
@@ -84,6 +87,12 @@ export class PlotlyChartElement extends LitElement {
           responsive: true 
         }
       });
+      wrapper.on('plotly_afterplot', () => {
+          const loadingIndicator = this.shadowRoot?.querySelector<LoadingIndicatorElement>("loading-indicator-element")
+          if (!loadingIndicator) return;
+          loadingIndicator.hide();
+      });
+
     });
   }
 
@@ -105,6 +114,9 @@ export class PlotlyChartElement extends LitElement {
   }
 
   render() {
-    return html`<slot></slot>`;
+    return html`
+      <loading-indicator-element></loading-indicator-element>
+      <slot></slot>
+    `;
   }
 }

--- a/frontend/src/components/plotly-chart-element/PlotlyChartElement.ts
+++ b/frontend/src/components/plotly-chart-element/PlotlyChartElement.ts
@@ -87,7 +87,7 @@ export class PlotlyChartElement extends LitElement {
           responsive: true 
         }
       });
-      wrapper.on('plotly_afterplot', () => {
+      (wrapper as any)?.on('plotly_afterplot', () => {
           const loadingIndicator = this.shadowRoot?.querySelector<LoadingIndicatorElement>("loading-indicator-element")
           if (!loadingIndicator) return;
           loadingIndicator.hide();


### PR DESCRIPTION
Adds a loading indicator to plotly plots and aladin-lite to show that things are still loading.

<img width="640" height="559" alt="output" src="https://github.com/user-attachments/assets/22de6b8c-ded7-415d-aee8-e4f2b13400a1" />

Fixes #208 